### PR TITLE
Update attributes source due to deprecation

### DIFF
--- a/custom_components/bkk_stop/sensor.py
+++ b/custom_components/bkk_stop/sensor.py
@@ -67,7 +67,7 @@ class BKKPublicTransportSensor(Entity):
         self._session = async_get_clientsession(self._hass)
 
     @property
-    def device_state_attributes(self):
+    def extra_state_attributes(self):
         bkkjson = {}
         bkkdata = self._bkkdata
 


### PR DESCRIPTION
update device_state_attributes to extra_state_attributes as device_state_attributes was deprecated

device_state_attributes comment: This method is deprecated, platform classes should implement extra_state_attributes instead.
https://github.com/home-assistant/core/blob/4c7e1fe0609a0c676bb4adacf0c1b3f19566904b/homeassistant/helpers/entity.py
https://github.com/home-assistant/core/commit/aaeaed4117d12ee2e780dfceed53cb52875eec1c